### PR TITLE
More benchmark

### DIFF
--- a/src/Nethermind.Verkle.Bench/BenchCurveOps.cs
+++ b/src/Nethermind.Verkle.Bench/BenchCurveOps.cs
@@ -1,6 +1,7 @@
 // Copyright 2022 Demerzel Solutions Limited
 // Licensed under Apache-2.0.For full terms, see LICENSE in the project root.
 
+using System.Threading.Tasks.Dataflow;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Nethermind.Verkle.Curve;
@@ -13,6 +14,13 @@ namespace Nethermind.Verkle.Bench;
 [MemoryDiagnoser]
 public class BenchCurveOps
 {
+    [Params(1, 2, 4, 8, 16, 32, 256)]
+    // [Params(256)]
+    public int InputSize { get; set; }
+
+    [Params(1, 4)]
+    public int Parallelism { get; set; }
+
     private readonly FrE[] _a;
 
     public BenchCurveOps()
@@ -33,6 +41,33 @@ public class BenchCurveOps
     [Benchmark]
     public void BenchmarkMultiScalarMul()
     {
-        Banderwagon.MultiScalarMul(Crs.BasisG, _a);
+        Banderwagon.MultiScalarMul(Crs.BasisG[..InputSize], _a[..InputSize], Parallelism);
+    }
+
+    [Benchmark]
+    public void BenchmarkScalarMul()
+    {
+        SpinLock accumulationLock = new SpinLock();
+        Banderwagon accumulation = Banderwagon.Identity;
+
+        ActionBlock<int> accumulator = new ActionBlock<int>((i) =>
+        {
+            Banderwagon multiplierd = Banderwagon.ScalarMul(Crs.BasisG[i], _a[i]);
+            bool locked = false;
+            accumulationLock.Enter(ref locked);
+            accumulation += multiplierd;
+            accumulationLock.Exit();
+        }, new ExecutionDataflowBlockOptions()
+        {
+            MaxDegreeOfParallelism = Parallelism,
+        });
+
+        for (int i = 0; i < InputSize; i++)
+        {
+            accumulator.Post(i);
+        }
+
+        accumulator.Complete();
+        accumulator.Completion.Wait();
     }
 }

--- a/src/Nethermind.Verkle/Curve/Banderwagon.MultiScalarMulti.cs
+++ b/src/Nethermind.Verkle/Curve/Banderwagon.MultiScalarMulti.cs
@@ -1,6 +1,7 @@
 // Copyright 2022 Demerzel Solutions Limited
 // Licensed under Apache-2.0.For full terms, see LICENSE in the project root.
 
+using System.Threading.Tasks.Dataflow;
 using Nethermind.Verkle.Fields.FpEElement;
 using Nethermind.Verkle.Fields.FrEElement;
 
@@ -18,25 +19,32 @@ public readonly partial struct Banderwagon
         for (int i = 0; i < numOfPoints; i++) normalizedPoints[i] = points[i].ToAffine(inverses[i]);
     }
 
-    public static Banderwagon MultiScalarMul(in ReadOnlySpan<Banderwagon> points, Span<FrE> scalars)
+    public static Banderwagon MultiScalarMul(in ReadOnlySpan<Banderwagon> points, Span<FrE> scalars, int threadCount = 0)
     {
         AffinePoint[] normalizedPoint = new AffinePoint[points.Length];
         BatchNormalize(points, normalizedPoint);
-        return MultiScalarMulFast(normalizedPoint, scalars.ToArray());
+        return MultiScalarMulFast(normalizedPoint, scalars.ToArray(), threadCount);
     }
 
-    private static FrE[] BatchConvertFromMontgomery(FrE[] scalarsMont)
+    private static FrE[] BatchConvertFromMontgomery(FrE[] scalarsMont, ExecutionDataflowBlockOptions options)
     {
         FrE[] scalars = new FrE[scalarsMont.Length];
-        Parallel.For(0, scalarsMont.Length, i =>
+        ActionBlock<int> setBlock = new ActionBlock<int>((i) =>
         {
             FrE.FromMontgomery(in scalarsMont[i], out scalars[i]);
-        });
+        }, options);
+        for (int i = 0; i < scalarsMont.Length; i++)
+        {
+            setBlock.Post(i);
+        }
+        setBlock.Complete();
+        setBlock.Completion.Wait();
+
         return scalars;
     }
 
 
-    private static Banderwagon MultiScalarMulFast(IReadOnlyList<AffinePoint> points, FrE[] scalars)
+    private static Banderwagon MultiScalarMulFast(IReadOnlyList<AffinePoint> points, FrE[] scalars, int threadCount)
     {
         int numOfPoints = points.Count;
         int windowsSize = numOfPoints < 32 ? 3 : (int)(Math.Log2(numOfPoints) * 69 / 100) + 2;
@@ -53,11 +61,15 @@ public readonly partial struct Banderwagon
 
         ulong bucketSize = ((ulong)1 << windowsSize) - 1;
 
-        FrE[] scalarsReg = BatchConvertFromMontgomery(scalars);
+        ExecutionDataflowBlockOptions options = new()
+        {
+            MaxDegreeOfParallelism = threadCount == 0 ? Environment.ProcessorCount : threadCount
+        };
+        FrE[] scalarsReg = BatchConvertFromMontgomery(scalars, options);
 
         Banderwagon[] windowSums = new Banderwagon[windowsStart.Count];
 
-        Parallel.For(0, windowsStart.Count, w =>
+        ActionBlock<int> windowAction = new ActionBlock<int>((w) =>
         {
             int winStart = windowsStart[w];
 
@@ -90,7 +102,14 @@ public readonly partial struct Banderwagon
             }
 
             windowSums[w] = res;
-        });
+        }, options);
+
+        for (int j = 0; j < windowsStart.Count; j++)
+        {
+            windowAction.Post(j);
+        }
+        windowAction.Complete();
+        windowAction.Completion.Wait();
 
         Banderwagon lowest = windowSums[0];
 


### PR DESCRIPTION
- Add option to to specify parallelism for multiscalarmul.
- Add benchmark for parallelism x input size.

### Result
| Method                  | InputSize | Parallelism | Mean       | Error     | StdDev    | Gen0    | Allocated |
|------------------------ |---------- |------------ |-----------:|----------:|----------:|--------:|----------:|
| BenchmarkMultiScalarMul | 1         | 1           |   6.734 ms | 0.0987 ms | 0.0924 ms |       - |  72.68 KB |
| BenchmarkScalarMul      | 1         | 1           |   1.329 ms | 0.0056 ms | 0.0052 ms |       - |   2.03 KB |
| BenchmarkMultiScalarMul | 1         | 4           |   2.683 ms | 0.0533 ms | 0.0987 ms |  3.9063 |  73.35 KB |
| BenchmarkScalarMul      | 1         | 4           |   1.340 ms | 0.0255 ms | 0.0239 ms |       - |   2.13 KB |
| BenchmarkMultiScalarMul | 2         | 1           |   7.119 ms | 0.1350 ms | 0.1263 ms |       - |  72.97 KB |
| BenchmarkScalarMul      | 2         | 1           |   2.634 ms | 0.0459 ms | 0.0429 ms |       - |   2.04 KB |
| BenchmarkMultiScalarMul | 2         | 4           |   2.809 ms | 0.0532 ms | 0.0569 ms |  3.9063 |  73.72 KB |
| BenchmarkScalarMul      | 2         | 4           |   1.330 ms | 0.0097 ms | 0.0091 ms |       - |   2.19 KB |
| BenchmarkMultiScalarMul | 4         | 1           |   7.730 ms | 0.0480 ms | 0.0426 ms |       - |   73.6 KB |
| BenchmarkScalarMul      | 4         | 1           |   4.970 ms | 0.0271 ms | 0.0211 ms |       - |   2.04 KB |
| BenchmarkMultiScalarMul | 4         | 4           |   2.982 ms | 0.0174 ms | 0.0163 ms |  3.9063 |  74.48 KB |
| BenchmarkScalarMul      | 4         | 4           |   1.370 ms | 0.0062 ms | 0.0058 ms |       - |   2.31 KB |
| BenchmarkMultiScalarMul | 8         | 1           |   8.689 ms | 0.1222 ms | 0.1143 ms |       - |  74.86 KB |
| BenchmarkScalarMul      | 8         | 1           |  10.217 ms | 0.0786 ms | 0.0735 ms |       - |   2.05 KB |
| BenchmarkMultiScalarMul | 8         | 4           |   3.370 ms | 0.0500 ms | 0.0468 ms |  3.9063 |  75.75 KB |
| BenchmarkScalarMul      | 8         | 4           |   2.716 ms | 0.0228 ms | 0.0213 ms |       - |   2.32 KB |
| BenchmarkMultiScalarMul | 16        | 1           |  11.344 ms | 0.0769 ms | 0.0600 ms |       - |   77.4 KB |
| BenchmarkScalarMul      | 16        | 1           |  20.687 ms | 0.2011 ms | 0.1783 ms |       - |   2.06 KB |
| BenchmarkMultiScalarMul | 16        | 4           |   3.976 ms | 0.0562 ms | 0.0499 ms |       - |  78.27 KB |
| BenchmarkScalarMul      | 16        | 4           |   5.410 ms | 0.0156 ms | 0.0146 ms |       - |   2.32 KB |
| BenchmarkMultiScalarMul | 32        | 1           |  21.160 ms | 0.2956 ms | 0.2765 ms |       - | 171.82 KB |
| BenchmarkScalarMul      | 32        | 1           |  41.755 ms | 0.0796 ms | 0.0744 ms |       - |    3.1 KB |
| BenchmarkMultiScalarMul | 32        | 4           |   6.510 ms | 0.0453 ms | 0.0401 ms |  7.8125 | 171.23 KB |
| BenchmarkScalarMul      | 32        | 4           |  10.774 ms | 0.0836 ms | 0.0782 ms |       - |   2.33 KB |
| BenchmarkMultiScalarMul | 256       | 1           |  78.732 ms | 0.3152 ms | 0.2795 ms |       - |  539.7 KB |
| BenchmarkScalarMul      | 256       | 1           | 326.580 ms | 1.7535 ms | 1.6402 ms |       - |  11.34 KB |
| BenchmarkMultiScalarMul | 256       | 4           |  21.976 ms | 0.0777 ms | 0.0689 ms | 31.2500 |  543.4 KB |
| BenchmarkScalarMul      | 256       | 4           |  84.804 ms | 0.1194 ms | 0.1059 ms |       - |  13.73 KB |
